### PR TITLE
Add option to specify listening host

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,8 @@ var (
 	host = app.Flag("host", "database server host (default: localhost)").
 		OverrideDefaultFromEnvar("PGHOST").
 		Short('h').PlaceHolder("HOSTNAME").String()
+	webHost = app.Flag("web-host", "web application host (default: 127.0.0.1)").
+		Short('H').Default("127.0.0.1").PlaceHolder("WEBHOST").String()
 	webPort = app.Flag("web-port", "web application port (default: 2345)").
 		Short('P').Default("2345").PlaceHolder("WEBPORT").Int()
 	port = app.Flag("port", "database server port (default: 5432)").
@@ -113,7 +115,7 @@ func main() {
 	db := connectDB(*host, *database, *username, pwd, *sslmode, *port)
 	context := &appContext{db, &metrics}
 	log.Printf("Starting Pome %s", Version)
-	log.Printf("Application will be available at http://127.0.0.1:%d", *webPort)
+	log.Printf("Application will be available at http://%s:%d", *webHost, *webPort)
 
 	initScheduler(
 		db,
@@ -124,5 +126,5 @@ func main() {
 		*scheduleNumConn,
 		*scheduleTPS,
 	)
-	initWebServer(context, *webPort)
+	initWebServer(context, *webHost, *webPort)
 }

--- a/web.go
+++ b/web.go
@@ -48,13 +48,13 @@ func newStaticHandler() http.Handler {
 	return http.FileServer(&fs)
 }
 
-func initWebServer(context *appContext, webPort int) {
+func initWebServer(context *appContext, webHost string, webPort int) {
 	http.Handle("/api/stats", appHandler{context, metricsHandler})
 	http.HandleFunc("/about", aliasHandler)
 	http.HandleFunc("/bloat/indexes", aliasHandler)
 	http.HandleFunc("/bloat/tables", aliasHandler)
 	http.Handle("/", newStaticHandler())
-	http.ListenAndServe(fmt.Sprintf(":%d", webPort), nil)
+	http.ListenAndServe(fmt.Sprintf("%s:%d", webHost, webPort), nil)
 }
 
 func (ah appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
As the subject says. This allows the user to start pome and accept connections on the public interface, thus the postgresql stats can be accessed on a remote server without having to create a SSH tunnel.
